### PR TITLE
flow-type-transformer github page no longer works

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,6 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 - [database-types](https://github.com/gajus/database-types) – A generic type generator for various databases.
 - [flow-static-land](https://www.npmjs.com/package/flow-static-land) - Implementation of common algebraic types in JavaScript + Flow
-- [flow-type-transformer](https://github.com/Dash-OS/flow-type-transformer) - Makes transforming values while retaining 100% Flow coverage dead simple.
 - [type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability
 - [decoders](https://github.com/nvie/decoders) - 🛡 Type-safe data validation for Flow
 


### PR DESCRIPTION
flow-type-transformer github page no longer works so let's remove the link. The npm package is there still: https://www.npmjs.com/package/flow-type-transformer but at least I would find it too shady if there is no associated github repo