### PR TITLE
eslint-plugin-flowtype-errors is depreacated

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
 - [babel-plugin-transform-flow-strip-types](https://www.npmjs.com/package/babel-plugin-transform-flow-strip-types) - Strip flow type annotations from your output code.
 - [babel-plugin-typecheck](https://github.com/codemix/babel-plugin-typecheck) - Static and runtime type checking for JavaScript in the form of a Babel plugin.
-- [eslint-plugin-flowtype-errors](https://github.com/amilajack/eslint-plugin-flowtype-errors) - Get flow errors as eslint errors
+- [eslint-plugin-flowtype](https://github.com/gajus/eslint-plugin-flowtype) - Get flow errors as eslint errors
 - [eslint-plugin-flow-vars](https://www.npmjs.com/package/eslint-plugin-flow-vars)
 - [flow](https://github.com/flowtype/flow-bin) - Binary wrapper for Flow
 - [flowgen](https://github.com/joarwilk/flowgen) - Generate flowtype definition files from TypeScript


### PR DESCRIPTION
let's switch to eslint-plugin-flowtype as it's successor of eslint-plugin-flowtype-errors